### PR TITLE
use dotenvy instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/davidpdrsn/load-dotenv.git"
 
 [dependencies]
-dotenv = "0.15"
+dotenvy = "0.15"
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! This is a small procedural macro to load your `.env` file at compile time. That way you can use
 //! [`std::env!`][] to load environment variables and fail the build if a variable is missing.
 //!
-//! All it does is call the [dotenv](https://crates.io/crates/dotenv) crate.
+//! All it does is call the [dotenvy](https://crates.io/crates/dotenvy) crate.
 //!
 //! # Example
 //!
@@ -32,7 +32,7 @@ use proc_macro::TokenStream;
 /// Load the `.env` file and panic if the file is missing.
 #[proc_macro]
 pub fn load_dotenv(_: TokenStream) -> TokenStream {
-    dotenv::dotenv().expect("Failed to load .env file");
+    dotenvy::dotenv().expect("Failed to load .env file");
 
     TokenStream::new()
 }
@@ -40,7 +40,7 @@ pub fn load_dotenv(_: TokenStream) -> TokenStream {
 /// Load the `.env` file but don't panic if the file is missing.
 #[proc_macro]
 pub fn try_load_dotenv(_: TokenStream) -> TokenStream {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     TokenStream::new()
 }


### PR DESCRIPTION
`dotenv` is unmaintained. This makes a non-breaking change to use `dotenvy`